### PR TITLE
chore: Sync with rhiza

### DIFF
--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -95,5 +95,5 @@ files:
 - docs/mkdocs-base.yml
 - pytest.ini
 - ruff.toml
-synced_at: '2026-04-25T03:51:21Z'
+synced_at: '2026-04-27T00:46:41Z'
 strategy: merge


### PR DESCRIPTION
## 🔄 Template Synchronization

This PR synchronizes the repository with the [jebel-quant/rhiza](https://github.com/jebel-quant/rhiza) template.

### 📊 Change Summary

- **0** files added
- **1** files modified
- **0** files deleted

### 📁 Changes by Category

#### Rhiza Configuration

<details>
<summary>Modified (1)</summary>

- 📝 `.rhiza/template.lock`

</details>

---

**🤖 Generated by [rhiza](https://github.com/jebel-quant/rhiza-cli)**

- Template: `jebel-quant/rhiza@main`
- Last sync: 2026-04-25T07:57:00+04:00
- Sync date: 2026-04-27T00:46:42.455501+00:00