### PR TITLE
fix: install jsharpe (non-editable) so the book build can import it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,13 @@ DEFAULT_AI_MODEL=claude-sonnet-4.6
 LOGO_FILE=.rhiza/assets/rhiza-logo.svg
 GH_AW_ENGINE ?= copilot  # Default AI engine for gh-aw workflows (copilot, claude, or codex)
 
-# Override template default: include mkdocstrings plugin for API docs
-MKDOCS_EXTRA_PACKAGES = --with 'mkdocstrings[python]'
+# Override template default: install the package itself (non-editable) so
+# mkdocstrings can import `jsharpe` to render the API reference, plus the
+# mkdocstrings[python] plugin. The package uses a src/ layout, so without
+# `--with .` the ephemeral uvx build env lacks it and `make book` fails with
+# ModuleNotFoundError. We use `--with .` (not `--with-editable .`) to honour
+# the template's no-editable-install policy.
+MKDOCS_EXTRA_PACKAGES = --with . --with 'mkdocstrings[python]'
 
 # Always include the Rhiza API (template-managed)
 include .rhiza/rhiza.mk


### PR DESCRIPTION
## Problem
The `book` workflow (mkdocs/zensical docs build) fails on `main`:

```
mkdocstrings: ... accessing 'jsharpe' raises ModuleNotFoundError: No module named 'jsharpe'
Python error: PluginError: Could not collect 'jsharpe'
make: *** [.rhiza/make.d/book.mk:52: book] Error 1
```

## Root cause
The v0.19.3 Rhiza sync (#242) replaced the repo-owned `MKDOCS_EXTRA_PACKAGES` override with the upstream default, which installs **no** local package:

```make
MKDOCS_EXTRA_PACKAGES = --with 'mkdocstrings[python]'
```

`docs-coverage` still passed because interrogate only *parses* source, but the real book build runs `uvx $(MKDOCS_EXTRA_PACKAGES) zensical build` in an **ephemeral** env. The package uses a `src/` layout, so `jsharpe` isn't importable there and mkdocstrings can't collect it to render the API reference.

## Fix
Add `--with .` so the (built, non-editable) package is installed into the build env:

```make
MKDOCS_EXTRA_PACKAGES = --with . --with 'mkdocstrings[python]'
```

Deliberately **not** `--with-editable .`: the template policy — enforced by `.rhiza/tests/integration/test_docs_targets.py::test_default_book_command_does_not_use_editable_install` — forbids an editable install in the default book command. `--with .` satisfies that policy while making the package importable. `Makefile` is repo-owned, so the override survives future syncs.

## Verification
- `make book` — ✅ builds cleanly (`No issues found` / `Book built at _book/`); previously failed.
- `make validate` — ✅ EXIT 0, **127 passed, 1 skipped** (the docs-targets policy test now passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)