### PR TITLE
feat: add ClusterFuzzLite fuzzing scaffold for jsharpe

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,9 @@
+# ClusterFuzzLite build image for jsharpe.
+# Uses the OSS-Fuzz Python base image, which provides Atheris and the
+# compile_python_fuzzer helper.
+# Pinned by SHA256 so the build image only changes through reviewed updates.
+FROM gcr.io/oss-fuzz-base/base-builder-python@sha256:99c714c91ec30778a3ce3ae5b37491a81fc043808bc8f2955159c2f608f80116
+
+COPY . $SRC
+WORKDIR $SRC
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+# ClusterFuzzLite build script — installs jsharpe and compiles each Python
+# harness in tests/fuzz/ via OSS-Fuzz's compile_python_fuzzer helper.
+
+cd "$SRC"
+
+# Pin pip so the build environment is reproducible and only changes through a
+# reviewed bump (the same rationale as the SHA-pinned base image).
+pip3 install --upgrade "pip==24.3.1"
+
+# Install the package and its runtime dependencies (numpy, scipy) into the build
+# environment so PyInstaller can discover and bundle jsharpe into each frozen
+# fuzzer binary.
+pip3 install .
+
+# PyInstaller does not discover the compiled extension modules of numpy/scipy on
+# their own, so the frozen fuzzer crashes at runtime (numpy: "No module named
+# 'numpy._core._exceptions'"; scipy: "extension modules cannot be imported").
+# --collect-all pulls in every submodule, data file and shared library for both.
+for fuzzer in tests/fuzz/fuzz_*.py; do
+  compile_python_fuzzer "$fuzzer" --collect-all numpy --collect-all scipy
+done

--- a/tests/fuzz/fuzz_sharpe.py
+++ b/tests/fuzz/fuzz_sharpe.py
@@ -1,0 +1,70 @@
+"""Fuzz the jsharpe linear-algebra helpers against arbitrary matrices/sizes.
+
+``ppoints`` builds plotting positions from an integer count, while
+``robust_covariance_inverse``, ``minimum_variance_weights_for_correlated_assets``
+and ``effective_rank`` consume square covariance-shaped matrices. None of them
+should crash with an unexpected exception on adversarial input — they should
+return a result or raise a documented error (or numpy's ``LinAlgError``). This
+harness exercises that contract with coverage-guided input.
+
+Run locally:
+    pip install atheris numpy scipy
+    python tests/fuzz/fuzz_sharpe.py -atheris_runs=20000
+
+Run in ClusterFuzzLite: this file is built by .clusterfuzzlite/build.sh.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+
+import atheris
+
+# Pre-import the native dependencies OUTSIDE the instrumentation block so they
+# load uninstrumented; atheris's import hook can miscompile C-accelerated
+# libraries. Only the first-party package under test is instrumented.
+import numpy as np
+import scipy.linalg  # noqa: F401  # pre-imported uninstrumented
+
+with atheris.instrument_imports():
+    from jsharpe.sharpe import (
+        effective_rank,
+        minimum_variance_weights_for_correlated_assets,
+        ppoints,
+        robust_covariance_inverse,
+    )
+
+# Errors the routines may legitimately raise on adversarial input. Anything
+# outside this set propagates and is recorded by Atheris as a crash.
+_ALLOWED = (ValueError, ZeroDivisionError, np.linalg.LinAlgError, FloatingPointError)
+
+
+def _matrix(fdp: atheris.FuzzedDataProvider) -> np.ndarray:
+    """Build an n x n float64 matrix from fuzzed bytes (n in [0, 8])."""
+    n = fdp.ConsumeIntInRange(0, 8)
+    floats = [fdp.ConsumeFloat() for _ in range(n * n)]
+    return np.array(floats, dtype=np.float64).reshape(n, n)
+
+
+def test_one_input(data: bytes) -> None:
+    """Run fuzzed sizes/matrices through the jsharpe helpers."""
+    fdp = atheris.FuzzedDataProvider(data)
+
+    with contextlib.suppress(_ALLOWED):
+        ppoints(fdp.ConsumeIntInRange(0, 64))
+
+    matrix = _matrix(fdp)
+    for fn in (robust_covariance_inverse, minimum_variance_weights_for_correlated_assets, effective_rank):
+        with contextlib.suppress(_ALLOWED):
+            fn(matrix)
+
+
+def main() -> None:
+    """Run the Atheris fuzz loop."""
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds the opt-in **ClusterFuzzLite** fuzzing scaffold so the existing `rhiza_fuzzing.yml` workflow actually runs.

- `.clusterfuzzlite/Dockerfile` — OSS-Fuzz Python base image, SHA-pinned
- `.clusterfuzzlite/build.sh` — installs the package and compiles each `tests/fuzz/fuzz_*.py` harness
- `tests/fuzz/fuzz_sharpe.py` — fuzzes `ppoints()` and the covariance helpers with arbitrary sizes/matrices. `--collect-all numpy --collect-all scipy`.

`FUZZING_ENABLED` is already set to `true`.

## Test plan
- [x] Built **and run** locally against the OSS-Fuzz `base-builder-python` image — 3000 runs, no crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience around numerical operations by adding broader fuzz coverage for edge cases and invalid inputs.
* **Tests**
  * Added a new fuzzing harness to exercise key statistical calculations with randomized inputs.
  * Expanded automated fuzz build support so multiple Python fuzz targets can be compiled consistently.
* **Chores**
  * Added container setup for the fuzzing environment to make builds reproducible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->