### PR TITLE
quality: reduce number_of_clusters complexity + add invariant tests (#263, #264)

### DIFF
--- a/src/jsharpe/sharpe/clustering.py
+++ b/src/jsharpe/sharpe/clustering.py
@@ -110,6 +110,59 @@ def _silhouette_samples(X: np.ndarray, labels: np.ndarray) -> np.ndarray:
     return np.where(max_ab > 0, (b - a) / max_ab, 0.0)
 
 
+def _assert_correlation_matrix(C: np.ndarray) -> None:
+    """Validate that ``C`` is a finite correlation matrix.
+
+    Checks that ``C`` is a numpy array with all entries in ``[-1, 1]``, ones on
+    the diagonal, and no non-finite values.
+
+    Args:
+        C: Candidate correlation matrix.
+    """
+    assert isinstance(C, np.ndarray)
+    assert np.all(C >= -1)
+    assert np.all(C <= 1)
+    assert np.all(np.diag(C) == 1)
+    assert np.all(np.isfinite(C))
+
+
+def _best_clustering_for_k(D: np.ndarray, k: int, *, retries: int) -> tuple[float, np.ndarray | None]:
+    """Run k-means ``retries`` times for a fixed ``k`` and return the best solution.
+
+    Degenerate runs (fewer than ``k`` non-empty clusters, or silhouette scores
+    with zero spread) are skipped. Quality is the mean silhouette score divided
+    by its standard deviation.
+
+    Args:
+        D: Distance matrix used as the feature matrix for k-means.
+        k: Number of clusters to fit.
+        retries: Number of k-means restarts to reduce sensitivity to the random
+            initialisation.
+
+    Returns:
+        Tuple of (quality, labels) for the best valid run, or ``(-inf, None)``
+        if no run produced a valid clustering.
+    """
+    best_quality = -np.inf
+    best_labels: np.ndarray | None = None
+    for _ in range(retries):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            _centroids, labels = scipy.cluster.vq.kmeans2(D, k, minit="points", iter=300)
+        # Skip degenerate solutions with empty clusters
+        if len(np.unique(labels)) < k:
+            continue
+        silhouette_vals = _silhouette_samples(D, labels)
+        std = silhouette_vals.std()
+        if std == 0:
+            continue
+        q = float(silhouette_vals.mean() / std)
+        if q > best_quality:
+            best_quality = q
+            best_labels = labels.copy()
+    return best_quality, best_labels
+
+
 def number_of_clusters(
     C: np.ndarray,
     *,
@@ -159,11 +212,7 @@ def number_of_clusters(
         >>> labels.shape
         (20,)
     """
-    assert isinstance(C, np.ndarray)
-    assert np.all(C >= -1)
-    assert np.all(C <= 1)
-    assert np.all(np.diag(C) == 1)
-    assert np.all(np.isfinite(C))
+    _assert_correlation_matrix(C)
 
     max_clusters = min(max_clusters, C.shape[0] - 1)
 
@@ -174,22 +223,10 @@ def number_of_clusters(
     qualities: dict[int, float] = {}
     best_labels: dict[int, np.ndarray] = {}
     for k in range(2, max_clusters + 1):
-        qualities[k] = -np.inf
-        for _ in range(retries):
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                _centroids, labels = scipy.cluster.vq.kmeans2(D, k, minit="points", iter=300)
-            # Skip degenerate solutions with empty clusters
-            if len(np.unique(labels)) < k:
-                continue
-            silhouette_vals = _silhouette_samples(D, labels)
-            std = silhouette_vals.std()
-            if std == 0:
-                continue
-            q = float(silhouette_vals.mean() / std)
-            if q > qualities[k]:
-                qualities[k] = q
-                best_labels[k] = labels.copy()
+        quality, labels = _best_clustering_for_k(D, k, retries=retries)
+        qualities[k] = quality
+        if labels is not None:
+            best_labels[k] = labels
 
     # Select the best k among those for which a valid solution was found
     valid_k = {k: q for k, q in qualities.items() if k in best_labels}

--- a/tests/test_sharpe.py
+++ b/tests/test_sharpe.py
@@ -685,3 +685,89 @@ def test_number_of_clusters_raises_when_no_valid_solution():
     """A 2x2 matrix admits no k in [2, n-1], so no clustering is found and it raises."""
     with pytest.raises(RuntimeError, match="No valid clustering solution"):
         number_of_clusters(np.eye(2))
+
+
+# ---- behavioural / property invariants ----
+#
+# The tests above pin exact reference values. The ones below instead assert
+# behaviour that must hold for *any* correct implementation — bounds and
+# monotonicity in each argument — so they keep protecting the contract even if
+# the internal formulas are refactored.
+
+
+def test_sharpe_ratio_variance_positive_and_monotone_in_trials():
+    """Variance is strictly positive and monotone in the multiple-testing factor K."""
+    var_single = sharpe_ratio_variance(SR=0.5, T=24)
+    var_many = sharpe_ratio_variance(SR=0.5, T=24, K=20)
+    assert var_single > 0
+    assert var_many > 0
+    # The K-adjustment (moments_Mk) rescales the estimator variance monotonically in K.
+    assert var_many < var_single
+
+
+def test_sharpe_ratio_variance_shrinks_with_more_observations():
+    """More observations reduce the estimator variance (∝ 1/T)."""
+    var_short = sharpe_ratio_variance(SR=0.5, T=12)
+    var_long = sharpe_ratio_variance(SR=0.5, T=120)
+    assert var_long < var_short
+
+
+def test_probabilistic_sharpe_ratio_bounds_and_monotonicity():
+    """PSR lies in (0, 1), rises with the observed SR, and falls as the benchmark SR0 rises."""
+    psr = probabilistic_sharpe_ratio(SR=0.5, SR0=0.0, T=24)
+    assert 0.0 < psr < 1.0
+    # Monotone increasing in the observed Sharpe ratio.
+    psr_higher_sr = probabilistic_sharpe_ratio(SR=1.0, SR0=0.0, T=24)
+    assert psr_higher_sr > psr
+    # Monotone decreasing in the benchmark it must beat.
+    psr_harder_benchmark = probabilistic_sharpe_ratio(SR=0.5, SR0=0.3, T=24)
+    assert psr_harder_benchmark < psr
+
+
+def test_minimum_track_record_length_positive_and_stricter_alpha_needs_more_data():
+    """MinTRL is positive and grows as the confidence requirement tightens (smaller alpha)."""
+    mtrl_loose = minimum_track_record_length(SR=0.5, SR0=0.0, alpha=0.10)
+    mtrl_strict = minimum_track_record_length(SR=0.5, SR0=0.0, alpha=0.01)
+    assert mtrl_loose > 0
+    assert mtrl_strict > mtrl_loose
+
+
+def test_critical_sharpe_ratio_positive_and_falls_as_alpha_relaxes():
+    """SR_c to reject H0: SR=0 is positive and decreases as alpha is relaxed."""
+    sr_c_strict = critical_sharpe_ratio(SR0=0.0, T=24, alpha=0.01)
+    sr_c_loose = critical_sharpe_ratio(SR0=0.0, T=24, alpha=0.10)
+    assert sr_c_strict > 0
+    assert sr_c_loose < sr_c_strict
+
+
+def test_sharpe_ratio_power_bounds_and_grows_with_sample_and_effect():
+    """Power is in [0, 1] and increases with both sample size T and the alternative SR1."""
+    power = sharpe_ratio_power(SR0=0.0, SR1=0.5, T=24)
+    assert 0.0 <= power <= 1.0
+    # More observations -> more power.
+    assert sharpe_ratio_power(SR0=0.0, SR1=0.5, T=96) > power
+    # A larger true effect -> more power.
+    assert sharpe_ratio_power(SR0=0.0, SR1=0.8, T=24) > power
+
+
+def test_expected_maximum_sharpe_ratio_grows_with_trials():
+    """The expected maximum Sharpe ratio increases with the number of trials."""
+    e_few = expected_maximum_sharpe_ratio(number_of_trials=2, variance=0.1)
+    e_many = expected_maximum_sharpe_ratio(number_of_trials=50, variance=0.1)
+    assert e_many > e_few
+
+
+def test_pFDR_bounds_and_grows_with_alpha():
+    """PFDR is a probability in (0, 1) that increases as the Type-I error rate alpha grows."""
+    fdr = pFDR(p_H1=0.05, alpha=0.05, beta=0.3)
+    assert 0.0 < fdr < 1.0
+    # A more permissive test admits more false discoveries among rejections.
+    assert pFDR(p_H1=0.05, alpha=0.20, beta=0.3) > fdr
+
+
+def test_oFDR_bounds_and_falls_with_stronger_evidence():
+    """OFDR is a probability in (0, 1) that decreases as the observed SR strengthens."""
+    fdr_weak = oFDR(SR=0.3, SR0=0.0, SR1=0.5, T=24, p_H1=0.1)
+    fdr_strong = oFDR(SR=0.8, SR0=0.0, SR1=0.5, T=24, p_H1=0.1)
+    assert 0.0 < fdr_weak < 1.0
+    assert fdr_strong < fdr_weak


### PR DESCRIPTION
## Summary

Addresses the two quality-scorecard findings from the rhiza v1.1.3 boost (#262).

### #263 — reduce cyclomatic complexity of `number_of_clusters`
- Extracted `_assert_correlation_matrix(C)` (input validation) and `_best_clustering_for_k(D, k, retries=…)` (the per-k k-means retry/silhouette loop) out of `number_of_clusters`.
- `number_of_clusters` drops from **C (CC 15) → B (7)**; `uvx radon cc src -a -s` now reports **no block C-or-worse** anywhere in `src/` (average CC 2.57).
- Behaviour unchanged — pure refactor.

### #264 — behavioural/invariant test assertions
- Added bounds + monotonicity property tests for the public functions that previously had only exact reference-value checks: `sharpe_ratio_variance`, `probabilistic_sharpe_ratio`, `minimum_track_record_length`, `critical_sharpe_ratio`, `sharpe_ratio_power`, `expected_maximum_sharpe_ratio`, `pFDR`, `oFDR`.
- These pin the *contract* (e.g. PSR ∈ (0,1) and rises with observed SR; MinTRL grows as α tightens; oFDR falls as evidence strengthens) so it survives future formula refactors.

## Verification

| Gate | Result |
|------|--------|
| `make fmt` | ✅ PASS |
| `make typecheck` (ty + mypy --strict) | ✅ PASS |
| `make test` | ✅ PASS — **97 passed**, 100% coverage |
| `uvx radon cc src` | ✅ no C-or-worse blocks (avg A 2.57) |

Closes #263
Closes #264
