### PR TITLE
docs: public API & semver policy (#280); confirm mock removal (#279)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,46 @@ Std error (fat tails): 0.234
 - `adjusted_p_values_sidak()` - Šidák correction
 - `minimum_variance_weights_for_correlated_assets()` - Portfolio optimization
 
+## Public API & Versioning
+
+**The public API is exactly the set of names exported in `jsharpe.__all__`**
+(24 symbols, re-exported unchanged from `jsharpe.sharpe.__all__`). You can rely
+on these being importable directly from the top-level package:
+
+```python +RHIZA_SKIP
+from jsharpe import probabilistic_sharpe_ratio, control_for_FDR  # supported
+```
+
+Everything else is **internal** and may change or disappear in any release
+without notice, including:
+
+- underscore-prefixed helpers (e.g. `_fdr_posterior`, `_select_best_k`);
+- symbols reachable only through a submodule path (e.g.
+  `jsharpe.sharpe.quadrature.moments_Mk`), which are deliberately *not* in
+  `__all__`;
+- the internal module layout of the `jsharpe.sharpe` subpackage (see
+  [ARCHITECTURE.md](ARCHITECTURE.md)).
+
+### Semantic versioning
+
+Releases follow [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`).
+While the project is in the `0.y.z` series the API is still stabilising, so the
+guarantees are:
+
+| Change to the public surface | Version bump |
+| ---------------------------- | ------------ |
+| Backward-incompatible change/removal | `MINOR` while `0.x`; `MAJOR` from `1.0` on |
+| Backward-compatible addition (new export) | `MINOR` |
+| Bug fix with no API change | `PATCH` |
+
+### Deprecation policy
+
+A public symbol is never removed without warning. Before removal it is marked
+deprecated and emits a `DeprecationWarning` (documented in the changelog) for at
+least one `MINOR` release, so downstream code has a migration window. Removal
+then happens in the next version that is allowed to make a breaking change under
+the table above.
+
 ## Documentation
 
 - **[API Documentation](https://tschm.github.io/jsharpe)** - Complete API reference with detailed function documentation


### PR DESCRIPTION
Addresses the two quality-scorecard issues surfaced during the rhiza v1.2.1 update (#278).

### #280 — Document a deprecation / semver policy
Adds a **"Public API & Versioning"** section to the README defining:
- **Stable surface:** exactly the 24 names in `jsharpe.__all__` (re-exported unchanged from `jsharpe.sharpe.__all__`); everything else — underscore helpers, submodule-only symbols like `jsharpe.sharpe.quadrature.moments_Mk`, and the internal module layout — is explicitly internal.
- **Semver mapping:** breaking change → `MINOR` while in `0.x`, `MAJOR` from `1.0`; compatible addition → `MINOR`; fix → `PATCH`.
- **Deprecation window:** `DeprecationWarning` for ≥1 `MINOR` release before removal.

The illustrative import block is marked `+RHIZA_SKIP` so the README-validation test doesn't execute it (verified: the test still passes).

### #279 — Reduce conftest mock depth
**Already resolved by #281.** The `_mock_unavailable_modules` scaffolding lived in `tests/conftest.py` purely to support the bundled-reference fixture, which #281 removed — so `tests/conftest.py` is gone and no module-availability mocking remains. Tests now exercise real code paths; the only surviving mock is a targeted `monkeypatch` of `scipy.cluster.vq.kmeans2` in `test_clustering.py`, justified by the need for a deterministic clustering to hit the zero-spread skip branch. This PR carries the `Closes #279` so the tracker reflects that.

Closes #279
Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)