### PR TITLE
chore: update rhiza to v1.5.1

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.5.1
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.5.1
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.5.1
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.5.1
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.5.1
     secrets: inherit

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.5.1
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.5.1
     secrets: inherit

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: 8ef5b50907aaf9c29aaf24c8c8de34a015f486a6
+sha: de568b1e79e5871c58b4349762ce9dfd31d73e99
 repo: jebel-quant/rhiza
 host: github
-ref: v1.5.0
+ref: v1.5.1
 include: []
 exclude:
 - SECURITY.md
@@ -43,5 +43,5 @@ files:
 - pytest.ini
 - ruff.toml
 - tests/test_rhiza_packaging.py
-synced_at: '2026-08-22T12:09:16Z'
+synced_at: '2026-08-23T12:00:08Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v1.5.0"
+ref: "v1.5.1"
 
 profiles:
   - github-project


### PR DESCRIPTION
Bumps `jebel-quant/rhiza` from **v1.5.0** to **v1.5.1** and applies the sync.

9 file(s) changed — the workflow stubs' `uses: …@v1.5.0` pins move to `@v1.5.1`, plus `.rhiza/template.lock`:

- `.github/workflows/rhiza_benchmark.yml`
- `.github/workflows/rhiza_book.yml`
- `.github/workflows/rhiza_ci.yml`
- `.github/workflows/rhiza_codeql.yml`
- `.github/workflows/rhiza_marimo.yml`
- `.github/workflows/rhiza_scorecard.yml`
- `.github/workflows/rhiza_weekly.yml`
- `.rhiza/template.lock`
- `.rhiza/template.yml`

The sync exited **0** — no conflicts, nothing left unstaged in the working tree.

**No gates were run — run `/rhiza:quality` for a scorecard.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project automation workflows to the latest Rhiza release.
  * Updated the project template reference to the latest Rhiza release.
  * Incorporates maintenance improvements across benchmarking, CI, security checks, documentation, and scheduled workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->