### PR TITLE
chore: enable the github-paper template

### DIFF
--- a/.github/workflows/rhiza_paper.yml
+++ b/.github/workflows/rhiza_paper.yml
@@ -1,0 +1,44 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: Paper
+#
+# Purpose: Compile the LaTeX paper (docs/paper/*.tex) to a PDF and publish it
+#          as a downloadable workflow artifact. The durable copy is published by
+#          the book: `paper` is a prerequisite of `book`, and docs/paper/ sits
+#          inside the docs tree, so the PDF ships as a site asset.
+#
+#          It no longer pushes to an orphan `paper` branch (rhiza #1494): that
+#          ref cannot coexist with any `paper/<topic>` branch, so the push failed
+#          in exactly the repositories most likely to have one. A repository that
+#          still has the branch gets a warning naming it; delete it when nothing
+#          links to it.
+#
+# Trigger: On push/PR to main/master when docs/paper/** changes, or manual dispatch.
+
+name: "(RHIZA) PAPER"
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main, master ]
+    paths:
+      - 'docs/paper/**'
+      - '.github/workflows/rhiza_paper.yml'
+  pull_request:
+    branches: [ main, master ]
+    paths:
+      - 'docs/paper/**'
+      - '.github/workflows/rhiza_paper.yml'
+  workflow_dispatch:
+
+jobs:
+  paper:
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.5.1
+    secrets: inherit
+    # `contents: read` only. The `write` scope this stub used to grant existed solely for
+    # the retired branch push; compiling and uploading an artifact need no write access.
+    permissions:
+      contents: read

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -7,6 +7,7 @@ exclude:
 - SECURITY.md
 - .github/CONFIG.md
 templates:
+- github-paper
 - legal
 profiles:
 - github-project
@@ -23,6 +24,7 @@ files:
 - .github/workflows/rhiza_ci.yml
 - .github/workflows/rhiza_codeql.yml
 - .github/workflows/rhiza_marimo.yml
+- .github/workflows/rhiza_paper.yml
 - .github/workflows/rhiza_release.yml
 - .github/workflows/rhiza_scorecard.yml
 - .github/workflows/rhiza_weekly.yml
@@ -40,8 +42,9 @@ files:
 - docs/development/TESTS.md
 - docs/index.md
 - docs/mkdocs-base.yml
+- docs/paper/README.md
 - pytest.ini
 - ruff.toml
 - tests/test_rhiza_packaging.py
-synced_at: '2026-08-23T12:00:08Z'
+synced_at: '2026-08-23T12:40:36Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -5,6 +5,10 @@ profiles:
   - github-project
 
 templates:
+  # Ships .github/workflows/rhiza_paper.yml, which compiles docs/paper/*.tex into a PDF
+  # published as a workflow artifact (and, via the book, as a docs-site asset). Pulls in
+  # the `paper` bundle, whose docs/paper/README.md explains the layout the workflow expects.
+  - github-paper
   - legal
 
 # Paths the template ships but this repo owns outright. Written as destination

--- a/docs/paper/README.md
+++ b/docs/paper/README.md
@@ -1,0 +1,99 @@
+# LaTeX Paper
+
+This folder is where the `paper` bundle expects your LaTeX sources. `make paper`
+compiles them to a PDF with `latexmk`, and `make paper-clean` removes the build
+artifacts.
+
+## Layout
+
+Put the root document at the top level of this folder. Chapters, figures and
+bibliography files can live in subdirectories — only the top level is searched for a
+root document, because a chapter is an `\input`, not something to compile on its own.
+
+```
+docs/paper/
+├── main.tex          <- the root document
+├── references.bib
+├── chapters/
+│   └── introduction.tex
+└── figures/
+```
+
+## Which file gets compiled
+
+The root document is chosen by name, in this order:
+
+1. `main.tex`
+2. `paper.tex`
+3. the first `.tex` file alphabetically
+
+A folder holding one `.tex` file is unambiguous whatever it is called, which is the
+common case. Name it `main.tex` if you have several and want to be explicit.
+
+## Targets
+
+| target | does |
+| --- | --- |
+| `make paper` | `latexmk -pdf -bibtex -interaction=nonstopmode` on the root document |
+| `make paper-clean` | `latexmk -C` — removes the PDF and every auxiliary file |
+
+`latexmk` reruns pdflatex and bibtex until the cross-references and citations
+converge, so one invocation is enough however many passes the document needs. Both
+targets run with this folder as the working directory, so `\input` paths are relative
+to it and the auxiliary files land beside the source rather than at the repository
+root.
+
+## Requirements
+
+A LaTeX distribution providing `latexmk` — [MacTeX](https://www.tug.org/mactex/) on
+macOS, [TeX Live](https://www.tug.org/texlive/) elsewhere. Without it both targets
+skip with that as the reason rather than failing, so a contributor who does not build
+the paper is not blocked by it. Pass `--strict` to turn the skip into a failure where
+the paper *must* build, such as in CI.
+
+## Configuration
+
+The folder is `docs/paper` by default. Point the tasks somewhere else with a
+`paper-folder` setting:
+
+```toml
+[tool.rhiza-task]
+paper-folder = "manuscript"
+```
+
+## Continuous integration
+
+The `github-paper` bundle adds a workflow that compiles the paper and publishes the
+PDF as a build artifact. It triggers only on changes under `docs/paper/**`, so it
+costs nothing until there is a paper to build.
+
+The **durable** copy comes from the book rather than that artifact, which expires after
+30 days. `paper` is a prerequisite of `book`, and this folder sits inside the docs tree,
+so mkdocs sweeps the compiled PDF up as a site asset at a stable URL. Link it from the
+nav to make it reachable:
+
+```yaml
+nav:
+  - Paper: paper/main.pdf
+```
+
+### If your repository has a `paper` branch
+
+The workflow used to push the PDF to an orphan `paper` branch as well. **It no longer
+does**, and a repository that still has the branch will see a warning naming it.
+
+The push was removed because git refs are paths: `refs/heads/paper` cannot exist while
+`refs/heads/paper/anything` does. So opening a `paper/overview` topic branch — the most
+natural convention for the very feature this bundle serves — broke the push outright, and
+it stayed broken after that topic branch was merged, until somebody also deleted it.
+
+Nothing needs to change on your side unless something *reads* that branch — a badge, a
+Pages source, a direct link. Point those at the PDF in the built site instead, then delete
+the branch, which is now nobody's job to update:
+
+```bash
+git push origin --delete paper
+```
+
+Leaving it in place is harmless except that it holds a PDF frozen at the last run before
+this change, with nothing indicating so.


### PR DESCRIPTION
Adds `github-paper` to `.rhiza/template.yml` and syncs the two files it brings in, so
this repo picks up the same paper pipeline `pyhrp`, `proximal` and `TinyCTA` already use.

Template-owned files added by the sync:

- `.github/workflows/rhiza_paper.yml` — stub calling `jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.5.1`
- `docs/paper/README.md` — from the `paper` bundle, which `github-paper` requires; documents the layout the workflow expects

Nothing else changed: the template `ref` stays at `v1.5.1`, `profiles` and `exclude` are untouched.

**Costs nothing until there is a paper.** The workflow triggers only on `docs/paper/**`
and its own file, and the reusable workflow checks for `docs/paper/*.tex` first — with no
`.tex` present it prints a skip notice and does no TeX install. `mkdocs` is not in strict
mode here, so the new `docs/paper/README.md` sitting outside the nav does not fail the book.

No gates were run — run `/rhiza:quality` for a scorecard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
