### PR TITLE
build: derive the version from the git tag with hatch-vcs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [project]
 name = "jsharpe"
-version = "0.6.3"
+# Derived from the git tag by hatch-vcs (see [tool.hatch.version]) rather than written
+# here, so the tag is the single source of truth and no commit can disagree with it.
+dynamic = ["version"]
 description = "Probabilistic Sharpe ratio and related statistics."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -45,8 +47,20 @@ test = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+# Resolves [project].dynamic = ["version"] from `git describe`. Tags are vX.Y.Z and
+# hatch-vcs strips the leading "v" by default, so v0.6.3 builds 0.6.3; a commit off the
+# tag builds a PEP 440 dev version (0.6.4.dev40+g<sha>).
+#
+# This makes the build history-dependent: a shallow clone that cannot see the tag does
+# not fail, it silently builds 0.1.dev1+g<sha>. Every checkout in rhiza_release.yml uses
+# fetch-depth: 0, and its "Verify built distribution matches the tag" step parses the
+# filename in dist/ and fails the release unless it carries the tag -- nothing earlier
+# can catch a wrong derived version.
+source = "vcs"
 
 [tool.rhiza-task]
 # Settings recovered from the make layer that rhiza v1.4.0 retired (`Makefile`,
@@ -75,7 +89,13 @@ mkdocs-extra-packages = [".", "mkdocstrings[python]"]
 # "pytest-rhiza @ git+https://github.com/Jebel-Quant/pytest-rhiza@v0.2.0".
 # Preserving the repo's pin keeps `rhiza-test` running the same assertion set as before
 # the migration; the CLI default would silently move it back to v0.2.0.
-pytest-rhiza = "pytest-rhiza==0.2.1"
+#
+# Raised 0.2.1 -> 0.6.0 when [project].version became dynamic. Every release up to and
+# including 0.5.0 reads `project["version"]` unconditionally, so a derived version fails
+# test_version_follows_semver (empty string against the semver regex) and the git-tag
+# comparison (InvalidVersion on ""). 0.6.0 is the first release that asks whether the
+# version is dynamic and skips those two assertions; there is no older version to pin.
+pytest-rhiza = "pytest-rhiza==0.6.0"
 
 # NOT a migrated value — a fix. The make layer and the deleted `.rhiza/.env` both said
 # `docs/notebooks`, which is also the CLI default, but this repo keeps its notebooks in
@@ -116,7 +136,10 @@ marimo-folder = "book/marimo/notebooks"
 # silent: with no config found the tool falls back to `git describe` and can
 # cut a release at a version that already exists. `current_version` is
 # deliberately absent — bump-my-version reads [project].version natively, so
-# duplicating it here only creates something that can go stale.
+# duplicating it here only creates something that can go stale. There is no
+# [[tool.bumpversion.files]] entry either: [project].version is dynamic (see
+# [tool.hatch.version]), so nothing writes the version down and a release is a
+# tag, not an edit. The table stays only so a config is still discovered.
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:[-]?(?P<release>[a-z]+)[\\.]?(?P<pre_n>\\d+))?(?:\\+build\\.(?P<build_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}-{release}.{pre_n}+build.{build_n}",
@@ -137,16 +160,6 @@ values = ["dev", "alpha", "a", "beta", "b", "rc", "prod"]
 # Anchored to the [project] table on purpose: an unanchored `version = "..."`
 # search is applied to every occurrence in the file, so it would also rewrite
 # any [tool.*] table that happens to share the current number.
-[[tool.bumpversion.files]]
-filename = "pyproject.toml"
-regex = true
-search = '(?ms)^\[project\]((?:(?!^\[)[\s\S])*?)^version = "{current_version}"'
-replace = '[project]\1version = "{new_version}"'
-
-# uv.lock is deliberately absent: its `name = "jsharpe"` entry is regenerated
-# with `uv lock` after the bump. A search on the bare version string would also
-# rewrite any dependency sitting at the same number.
-
 # scipy ships no type stubs (scipy-stubs is a separate, partial package),
 # so mypy --strict cannot resolve its imports. Ignore the missing stubs
 # rather than pinning an out-of-tree stub package.

--- a/uv.lock
+++ b/uv.lock
@@ -425,7 +425,6 @@ wheels = [
 
 [[package]]
 name = "jsharpe"
-version = "0.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
`[project].version` was written as `0.6.3` and had to be kept in step with the tag by hand. This makes the **tag the single source of truth**, so no commit can disagree with it.

The pytest-rhiza pin moves from `0.2.1` to `0.6.0`.

Also drops the `[[tool.bumpversion.files]]` entry: it rewrote `[project].version`, which no longer exists, and `ignore_missing_version = false` would have turned that into a hard failure on the next bump. The `[tool.bumpversion]` table itself stays so bump-my-version still *discovers* a config rather than falling back to `git describe`.

## What changed

- `[project].version` → `dynamic = ["version"]`, resolved by **hatch-vcs** from `git describe`.
- `[build-system]` gains `hatch-vcs`; `[tool.hatch.version]` sets `source = "vcs"`.
- `pytest-rhiza` pinned to **0.6.0**. Not optional: every release up to and including 0.5.0 reads `project["version"]` unconditionally, so a derived version fails `test_version_follows_semver` (empty string against the semver regex) and the git-tag comparison (`InvalidVersion` on `""`). 0.6.0 is the first release that asks whether the version is dynamic and skips those assertions.
- `uv.lock` drops the `version` field from this project's own entry.

## Verified

A clean clone tagged `v9.9.9` builds exactly `9.9.9` — the `v` stripped, no dev or local suffix — which is what `rhiza_release.yml`'s built-distribution filename check requires. Full test suite passes.

## Note

`uv sync` now rebuilds the project on every invocation: on a dirty tree hatch-vcs appends a date marker, so the version changes as the tree is edited.

A shallow clone that cannot see the tag does **not** fail — it silently builds `0.1.dev1+g<sha>`. Every checkout in `rhiza_release.yml` uses `fetch-depth: 0`, and the built-distribution check is the backstop.

---
No gates were run beyond the test suite; use `/rhiza:quality` for a scorecard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Project versions are now derived automatically from Git tags.
  * Updated release tooling to support dynamic versioning.
  * Updated the project task tool to a newer version.
  * Removed manual version updates from the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->